### PR TITLE
Windows MinGW build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# C++ objects and libs
+
+*.slo
+*.lo
+*.o
+*.a
+*.la
+*.lai
+*.so
+*.dll
+*.dylib
+
+# Qt-es
+
+/.qmake.cache
+/.qmake.stash
+*.pro.user
+*.pro.user.*
+*.qbs.user
+*.qbs.user.*
+*.moc
+moc_*.cpp
+qrc_*.cpp
+ui_*.h
+Makefile*
+*build-*
+
+# QtCreator
+
+*.autosave
+
+# QtCtreator Qml
+*.qmlproject.user
+*.qmlproject.user.*
+
+# QtCtreator CMake
+CMakeLists.txt.user

--- a/lib/lib.pri
+++ b/lib/lib.pri
@@ -1,3 +1,16 @@
-LIBS += $$OUT_PWD/../lib/librenderlib.a
-PRE_TARGETDEPS = $$OUT_PWD/../lib/librenderlib.a
+win32: Debug: {
+    PRE_TARGETDEPS = $$OUT_PWD/../lib/debug/librenderlib.a
+    LIBS += $$OUT_PWD/../lib/debug/librenderlib.a
+}
+
+win32: Release: {
+    PRE_TARGETDEPS = $$OUT_PWD/../lib/release/librenderlib.a
+    LIBS += $$OUT_PWD/../lib/release/librenderlib.a
+}
+
+!win32: {
+    PRE_TARGETDEPS = $$OUT_PWD/../lib/librenderlib.a
+    LIBS += $$OUT_PWD/../lib/librenderlib.a
+}
+
 INCLUDEPATH += ../lib/


### PR DESCRIPTION
Builds on msys2/mingw64, should also build with bundled 32-bit MinGW.

I don't really use MSVC so that's probably still broken.

~~Fixes #1.~~ No wait, sorry it doesn't! Should be easy to tweak for MSVC though.

I've also added a [.gitignore](https://github.com/github/gitignore/blob/master/Qt.gitignore).
